### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ YouTube:
 [![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/X1YvxDMr0yA/0.jpg)](http://www.youtube.com/watch?v=X1YvxDMr0yA)
 
 
-###How to install
+### How to install
 
 Install using CocoaPods.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
